### PR TITLE
Add bin to package.json and make it a binary.

### DIFF
--- a/bin/npm-css
+++ b/bin/npm-css
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // builtin
 var fs = require('fs');
 var path = require('path');

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "Raynos <raynos2@gmail.com>",
   "repository": "git://github.com/shtylman/npm-css.git",
   "main": "index",
+  "bin": {
+    "npm-css": "bin/npm-css"
+  },
   "contributors": [
     {
       "name": "Jake Verbaten"
@@ -17,11 +20,11 @@
   "dependencies": {
     "resolve": "0.2.3",
     "traverse": "0.6.3",
-    "cssp": "1.0.6"
+    "cssp": "1.0.6",
+    "optimist": "0.3.5"
   },
   "devDependencies": {
-    "tap": "~0.3.1",
-    "optimist": "~0.3.5"
+    "tap": "~0.3.1"
   },
   "licenses": [
     {


### PR DESCRIPTION
`npm install -g npm-css` wasn't giving me access to the `npm-css` command. This makes it run as a binary and has npm link it. Also `optimist` needed to move to the deps. Thanks!
