### PR TITLE
Add css module, change import, relevant test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "optimist": "0.3.5"
   },
   "devDependencies": {
-    "mocha": "~1.13.0"
+    "mocha": "~1.13.0",
+    "foobar-npm-css": "1.0.0"
   },
   "licenses": [
     {

--- a/test/expected/input.css
+++ b/test/expected/input.css
@@ -5,33 +5,33 @@
 /* foobar stuff */
 
 /* .foobar */
-.foobar {}
+.foobar-npm-css .foobar {}
 
 /* p.foobar */
-p.foobar {}
+.foobar-npm-css p.foobar {}
 
 /* .foobar p .foobar */
-.foobar p .foobar {}
+.foobar-npm-css .foobar p .foobar {}
 
 /* .foorbar p */
-.foobar p {}
+.foobar-npm-css .foobar p {}
 
 /* .foobar p */
-.foobar p {}
+.foobar-npm-css .foobar p {}
 
 /* .foobar.baz */
-.foobar.baz {}
+.foobar-npm-css .foobar.baz {}
 
 /* .foobar .baz */
-.foobar .baz {}
+.foobar-npm-css .foobar .baz {}
 
 /* .foobar .baz */
-.foobar .baz {}
+.foobar-npm-css .foobar .baz {}
 
 /* .baz.foobar */
-.baz.foobar {}
+.foobar-npm-css .baz.foobar {}
 
 /* .foobar .baz .foobar */
-.foobar .baz .foobar {}
+.foobar-npm-css .foobar .baz .foobar {}
 
 

--- a/test/fixtures/input.css
+++ b/test/fixtures/input.css
@@ -1,3 +1,3 @@
 @import "./required.css";
-@import "foobar";
+@import "foobar-npm-css/foobar";
 


### PR DESCRIPTION
This is a fix for this issue https://github.com/defunctzombie/npm-css/issues/12

My guess is that the test is meant to demonstrate how to require files from the `node_modules` directory using `@import`. I've had to create an npm package with a slightly longer name so the class selectors in the example CSS is a bit more unwieldy. 
